### PR TITLE
Remove DOI checking

### DIFF
--- a/hakai_ckan_records_checks/__main__.py
+++ b/hakai_ckan_records_checks/__main__.py
@@ -244,9 +244,9 @@ def review_records(ckan: str, max_workers, records_ids: list = None) -> dict:
 )
 def main(ckan_url, record_ids, api_key, output, max_workers, log_level, cache):
     logger.remove()
-    logger.add(sys.stderr, level=log_level)
+    logger.add(tqdm.write, level=log_level, colorize=False)
 
-    logger.info("Starting checks for CKAN instance at {ckan_url}")
+    logger.info(f"Starting checks for CKAN instance at {ckan_url}")
     ckan = CKAN(ckan_url, api_key)
     if record_ids:
         record_ids = record_ids.split(",")

--- a/hakai_ckan_records_checks/__main__.py
+++ b/hakai_ckan_records_checks/__main__.py
@@ -244,7 +244,7 @@ def review_records(ckan: str, max_workers, records_ids: list = None) -> dict:
 )
 def main(ckan_url, record_ids, api_key, output, max_workers, log_level, cache):
     logger.remove()
-    logger.add(tqdm.write, level=log_level, colorize=False)
+    logger.add(lambda msg: tqdm.write(msg, end=""), level=log_level, colorize=False)
 
     logger.info(f"Starting checks for CKAN instance at {ckan_url}")
     ckan = CKAN(ckan_url, api_key)

--- a/hakai_ckan_records_checks/datacite.py
+++ b/hakai_ckan_records_checks/datacite.py
@@ -98,7 +98,11 @@ def compare_datacite_metadata(ckan_record, datacite_metadata):
 
     # Version
     dc_version = (attrs.get("version") or "").lstrip("v").strip()
-    ckan_version = (ckan_citation.get("version") or ckan_record.get("version") or "").lstrip("v").strip()
+    ckan_version = (
+        (ckan_citation.get("version") or ckan_record.get("version") or "")
+        .lstrip("v")
+        .strip()
+    )
     if dc_version and ckan_version and dc_version != ckan_version:
         issues.append(
             f"Metadata mismatch: version CKAN='{ckan_version}' | DataCite='{dc_version}'"
@@ -123,16 +127,22 @@ def compare_datacite_metadata(ckan_record, datacite_metadata):
 
     for dc_name in dc_creator_names:
         if not any(_fuzzy_match(dc_name, n) for n in ckan_author_names):
-            issues.append(f"Metadata mismatch: creator '{dc_name}' in DataCite not found in CKAN record")
+            issues.append(
+                f"Metadata mismatch: creator '{dc_name}' in DataCite not found in CKAN record"
+            )
 
     for ckan_name in ckan_author_names:
         if not any(_fuzzy_match(ckan_name, dc_name) for dc_name in dc_creator_names):
-            issues.append(f"Metadata mismatch: author '{ckan_name}' in CKAN record not found in DataCite")
+            issues.append(
+                f"Metadata mismatch: author '{ckan_name}' in CKAN record not found in DataCite"
+            )
 
     # Related works
     dc_related = attrs.get("relatedIdentifiers", [])
     dc_related_ids = {
-        _normalize_identifier(r.get("relatedIdentifier", ""), r.get("relatedIdentifierType", ""))
+        _normalize_identifier(
+            r.get("relatedIdentifier", ""), r.get("relatedIdentifierType", "")
+        )
         for r in dc_related
         if r.get("relationType") not in _SKIP_RELATION_TYPES
     }
@@ -155,7 +165,11 @@ def compare_datacite_metadata(ckan_record, datacite_metadata):
         rel_id = _normalize_identifier(
             rel.get("relatedIdentifier", ""), rel.get("relatedIdentifierType", "")
         )
-        if rel_type not in _SKIP_RELATION_TYPES and rel_id and rel_id not in ckan_related_ids:
+        if (
+            rel_type not in _SKIP_RELATION_TYPES
+            and rel_id
+            and rel_id not in ckan_related_ids
+        ):
             issues.append(
                 f"Metadata mismatch: related identifier '{rel.get('relatedIdentifier')}' ({rel_type}) in DataCite not found in CKAN"
             )

--- a/hakai_ckan_records_checks/datacite.py
+++ b/hakai_ckan_records_checks/datacite.py
@@ -8,18 +8,8 @@ from hakai_ckan_records_checks.hakai import _fuzzy_match
 
 DATACITE_API_URL = "https://api.datacite.org/dois"
 
-RELATIONSHIPS_TRACKED = [
-    "references",
-    "citations",
-    "parts",
-    "partOf",
-    "versions",
-    "versionOf",
-]
-
 # relationType values auto-populated by DataCite (not manually curated)
 _SKIP_RELATION_TYPES = {"Cites", "IsCitedBy", "IsSupplementTo", "IsSupplementedBy"}
-
 
 
 def _normalize_identifier(identifier, id_type=""):
@@ -54,10 +44,6 @@ class Datacite:
 
 
 def get_datacite_summary(record):
-    def review_doi(doi):
-        response = requests.get(f"https://doi.org/{doi}")
-        return {"status_code": response.status_code, "url": response.url}
-
     if not record:
         return {}
     if record["data"]["attributes"]["citationCount"] > 0:
@@ -65,22 +51,9 @@ def get_datacite_summary(record):
             f"Found citation count: {record['data']['attributes']['citationCount']}"
         )
 
-    # Generate relationships table
-    if record["data"]["attributes"]["citationCount"]:
-        relationships = [
-            {"relationship": relationship, **item, **review_doi(item["id"])}
-            for relationship, attrs in record["data"]["relationships"].items()
-            if relationship in RELATIONSHIPS_TRACKED and attrs["data"]
-            for item in attrs["data"]
-        ]
-    else:
-        relationships = []
-    if relationships:
-        logger.debug(f"Found relationships: {relationships}")
     return {
         "citation_count": record["data"]["attributes"]["citationCount"],
         "citations_over_time": record["data"]["attributes"]["citationsOverTime"],
-        "relationships": relationships,
     }
 
 


### PR DESCRIPTION
This PR does three things:
- stop checking all the DOIs for every article on datacite since we never actually use that information. That was causing errors like this: https://github.com/HakaiInstitute/hakai-ckan-records-checks/actions/runs/26310318140/job/77457173196#step:5:313
- The log lines were bleeding into each other. This adds a progress bar aware log
- lint