### PR TITLE
minor update to metadata mismatch

### DIFF
--- a/hakai_ckan_records_checks/__main__.py
+++ b/hakai_ckan_records_checks/__main__.py
@@ -113,7 +113,20 @@ def review_records(ckan: str, max_workers, records_ids: list = None) -> dict:
         summary = hakai.get_record_summary(record["result"])
 
         logger.debug("Getting citation count for DOI")
-        datacite_metadata, error_msg = Datacite().get_doi(summary.get("doi"))
+        # Prefer a Hakai DOI (10.21966/) for DataCite lookups; the primary DOI may be
+        # an external archive DOI (e.g. NOAA 10.25921/) whose DataCite record lacks
+        # the related-identifier metadata that the Hakai record carries.
+        hakai_doi = summary.get("doi") or ""
+        if not hakai_doi.startswith("10.21966/"):
+            hakai_doi = next(
+                (
+                    a.get("aggregate-dataset-identifier_code", "").replace("https://doi.org/", "")
+                    for a in record["result"].get("aggregation-info", [])
+                    if "10.21966/" in a.get("aggregate-dataset-identifier_code", "")
+                ),
+                hakai_doi,
+            )
+        datacite_metadata, error_msg = Datacite().get_doi(hakai_doi)
         summary.update(get_datacite_summary(datacite_metadata))
         if error_msg:
             test_results.append([error_msg])

--- a/hakai_ckan_records_checks/datacite.py
+++ b/hakai_ckan_records_checks/datacite.py
@@ -21,6 +21,9 @@ def _normalize_identifier(identifier, id_type=""):
         identifier = re.sub(
             r"https?://(dx\.)?doi\.org/", "", identifier, flags=re.IGNORECASE
         )
+    elif re.match(r"https?://10\.", identifier, re.IGNORECASE):
+        # Malformed DOI URL missing doi.org (e.g. https://10.21966/abc instead of https://doi.org/10.21966/abc)
+        identifier = re.sub(r"https?://", "", identifier, flags=re.IGNORECASE)
     return identifier.lower()
 
 

--- a/hakai_ckan_records_checks/hakai.py
+++ b/hakai_ckan_records_checks/hakai.py
@@ -98,6 +98,14 @@ def test_record_requirements(record) -> pd.DataFrame:
                     f"DOI is not redirecting to Hakai's catalogue: {response.url}",
                 )
 
+    # Related Works — flag malformed DOI URLs (https://10.x instead of https://doi.org/10.x)
+    for agg in record.get("aggregation-info", []):
+        code = agg.get("aggregate-dataset-identifier_code", "")
+        _test(
+            not re.match(r"https?://10\.", code, re.IGNORECASE),
+            f"Malformed related work identifier (missing doi.org): {code}",
+        )
+
     # Contacts
     contacts = record.get("cited-responsible-party", []) + record.get(
         "metadata-point-of-contact", []


### PR DESCRIPTION
The CKAN Checker was still matching to earlier added DOIs. The fix now forces it to look for any mismatches in Hakai-minted DOIs and their CKAN catalogue record. Because it was still querying "old" DOIs - in this case, a DOI that was minted by NCEI. This produced metadata mismatches (see below), because the metadata associated with the NCEI DOI was compared to the metadata in our Hakai CKAN Catalogue. 

<img width="966" height="290" alt="image" src="https://github.com/user-attachments/assets/879bf8d7-5d97-45b3-bfc2-a4abab29c286" />

The bigger issue here perhaps also is that the DOI field in our Hakai CKAN Catalogue is not updating properly. For example, for [this record](https://catalogue.hakai.org/dataset/ca-cioos_4a09d56b-b120-46c8-9263-ae3c42a02e9b), the DOI is still 10.25921/kmam-ct93, whereas when I look in the Metadata Form, this DOI is 10.21966/1yev-s239. I think once the DOI field updates properly, the CKAN Checker will queries across the correct DOI - Hakai Catalogue record match. 

-- issue created for that: https://github.com/HakaiInstitute/hakai-ckan-records-checks/issues/35
